### PR TITLE
feat: update 'eslint-config with 'unicorn' plugin rules

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -66,6 +66,7 @@ configurations
   TS rules
 - `eslint-plugin-prettier` - disable code formatting using eslint tools and transfers all the logic to a prettier, and
   report differences as eslint issues
+- `eslint-plugin-unicorn` — provides specific rules for JS code to make it more consistent
 
 ## Troubleshooting
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,6 +7,7 @@ module.exports = {
     './internal/test-files',
     './internal/typescript',
     './internal/prettier',
+    './internal/unicorn',
   ],
 
   env: {

--- a/packages/eslint-config/internal/unicorn.js
+++ b/packages/eslint-config/internal/unicorn.js
@@ -1,0 +1,11 @@
+module.exports = {
+  plugins: ['unicorn'],
+  rules: {
+    'unicorn/no-abusive-eslint-disable': 'error',
+    'unicorn/no-instanceof-array': 'error',
+    'unicorn/no-new-buffer': 'error',
+    'unicorn/no-hex-escape': 'error',
+    'unicorn/custom-error-definition': 'error',
+    'unicorn/prefer-string-starts-ends-with': 'error',
+  },
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinkoff/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ESLint configs to rule them all",
   "license": "Apache-2.0",
   "keywords": [
@@ -30,6 +30,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-sort-class-members": "^1.17.1",
+    "eslint-plugin-unicorn": "^51.0.1",
     "prettier": "2.8.7"
   },
   "publishConfig": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
eslint-config is fine to:
 - escape `hex` in different ways
 - set `eslint-disable` comment to disable entire rules list
 - make `instanceof Array` instead `Array.isArray()`
 - ...some other mismatches which allows to write one functional code in different ways

## What is the new behavior?
- eslint-config become more strict for these cases

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
