### PR TITLE
fix: wide typescript-eslint to 7.x versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '16.x'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Clean install

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@babel/eslint-parser": "^7.21.3",
     "@babel/eslint-plugin": "^7.19.1",
-    "@typescript-eslint/eslint-plugin": "^6.7.2",
-    "@typescript-eslint/parser": "^6.7.2",
+    "@typescript-eslint/eslint-plugin": ">=6.7.2",
+    "@typescript-eslint/parser": ">=6.7.2",
     "eslint": "^8.38.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/tramvaijs/linters.git"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.7.2"
+    "@typescript-eslint/eslint-plugin": ">=6.7.2"
   },
   "peerDependencies": {
     "eslint": ">=8"


### PR DESCRIPTION
Please install `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`  6.7.2 or above in your project directly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Code style update
- [x] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` can be installed in end project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
